### PR TITLE
Fix encoding

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -257,7 +257,7 @@ func (g *GoFakeS3) listBucket(bucketName string, w http.ResponseWriter, r *http.
 		Contents:       objects.Contents,
 		IsTruncated:    objects.IsTruncated,
 		Delimiter:      prefix.Delimiter,
-		Prefix:         prefix.Prefix,
+		Prefix:         URLEncode(prefix.Prefix),
 		MaxKeys:        page.MaxKeys,
 	}
 

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -280,6 +280,7 @@ func (g *GoFakeS3) listBucket(bucketName string, w http.ResponseWriter, r *http.
 			KeyCount:             int64(len(objects.CommonPrefixes) + len(objects.Contents)),
 			StartAfter:           q.Get("start-after"),
 			ContinuationToken:    q.Get("continuation-token"),
+			EncodingType:         "url",
 		}
 		if objects.NextMarker != "" {
 			// We are just cheating with these continuation tokens; they're just the NextMarker

--- a/messages.go
+++ b/messages.go
@@ -248,7 +248,8 @@ type ListBucketResultV2 struct {
 	NextContinuationToken string `xml:"NextContinuationToken,omitempty"`
 
 	// If StartAfter was sent with the request, it is included in the response.
-	StartAfter string `xml:"StartAfter,omitempty"`
+	StartAfter   string `xml:"StartAfter,omitempty"`
+	EncodingType string `xml:"EncodingType,omitempty"`
 }
 
 type DeleteMarker struct {


### PR DESCRIPTION
running rclone to serve an S3 server with the code of https://github.com/rclone/rclone/pull/7062 (original PR: https://github.com/rclone/rclone/pull/6461) and Nextcloud as WebDAV backend I've noticed that having file/folder names that need encoding lead to issues.
When using the `mc ls` the files are listed in the encoded form and they cannot be copied via `mc cp --recursive` because mc will try to access the S3 keys by encoding again the names it received and so resulting in a double encoded URL

This PR also encodes the prefix & sets the encoding type in the response XML (details in the commit descriptions)