### PR TITLE
Implement authentication expiration check for S3 requests

### DIFF
--- a/signature/signature-errors.go
+++ b/signature/signature-errors.go
@@ -39,8 +39,10 @@ const (
 	errUnsignedHeaders
 	errMissingDateHeader
 	errMalformedDate
+	errMalformedExpires
 	errUnsupportAlgorithm
 	errSignatureDoesNotMatch
+	errExpiredRequest
 
 	// ErrNone is None(err=nil)
 	ErrNone
@@ -109,6 +111,11 @@ var errorCodes = errorCodeMap{
 		Description:    "Invalid date format header, expected to be in ISO8601, RFC1123 or RFC1123Z time format.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
+	errMalformedExpires: {
+		Code:           "MalformedExpires",
+		Description:    "Invalid X-Amz-Expires, expected to be a number",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
 	errUnsupportAlgorithm: {
 		Code:           "UnsupportedAlgorithm",
 		Description:    "Encountered an unsupported algorithm.",
@@ -118,6 +125,11 @@ var errorCodes = errorCodeMap{
 		Code:           "SignatureDoesNotMatch",
 		Description:    "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
 		HTTPStatusCode: http.StatusForbidden,
+	},
+	errExpiredRequest: {
+		Code:           "AccessDenied",
+		Description:    "The difference between the request time and the server's time exceeds the maximum allowed.",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 }
 

--- a/signature/signature-v4_test.go
+++ b/signature/signature-v4_test.go
@@ -121,3 +121,117 @@ func TestUnsignedPayload(t *testing.T) {
 		t.Errorf("invalid result for unsigned payload: expect none but got %+v", signature.GetAPIError(result))
 	}
 }
+
+func TestCheckExpiration(t *testing.T) {
+	originalTimeNow := signature.TimeNow
+	defer func() { signature.TimeNow = originalTimeNow }()
+
+	testCases := []struct {
+		name           string
+		useQueryString bool
+		expiresIn      string
+		timeDelta      time.Duration
+		expectedError  bool
+	}{
+		{
+			name:           "Valid Header-based Authentication (Default 15min)",
+			useQueryString: false,
+			expiresIn:      "",
+			timeDelta:      14 * time.Minute,
+			expectedError:  false,
+		},
+		{
+			name:           "Expired Header-based Authentication (Default 15min)",
+			useQueryString: false,
+			expiresIn:      "",
+			timeDelta:      16 * time.Minute,
+			expectedError:  true,
+		},
+		{
+			name:           "Valid Query-based Authentication (30min)",
+			useQueryString: true,
+			expiresIn:      "1800", // 30 minutes
+			timeDelta:      29 * time.Minute,
+			expectedError:  false,
+		},
+		{
+			name:           "Expired Query-based Authentication (30min)",
+			useQueryString: true,
+			expiresIn:      "1800", // 30 minutes
+			timeDelta:      31 * time.Minute,
+			expectedError:  true,
+		},
+		{
+			name:           "Valid Query-based Authentication (5min)",
+			useQueryString: true,
+			expiresIn:      "300", // 5 minutes
+			timeDelta:      4 * time.Minute,
+			expectedError:  false,
+		},
+		{
+			name:           "Expired Query-based Authentication (5min)",
+			useQueryString: true,
+			expiresIn:      "300", // 5 minutes
+			timeDelta:      6 * time.Minute,
+			expectedError:  true,
+		},
+		{
+			name:           "Malformed Expires",
+			useQueryString: true,
+			expiresIn:      "not-a-number",
+			timeDelta:      0,
+			expectedError:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			Body := bytes.NewReader(nil)
+			ak := RandString(32)
+			sk := RandString(64)
+			region := RandString(16)
+
+			creds := credentials.NewStaticCredentials(ak, sk, "")
+			signature.ReloadKeys(map[string]string{ak: sk})
+			signer := v4.NewSigner(creds)
+
+			req, err := http.NewRequest(http.MethodPost, "https://s3-endpoint.example.com/bin", Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			now := time.Now()
+			signature.TimeNow = func() time.Time { return now }
+
+			if tc.useQueryString {
+				// For query-based authentication
+				req.URL.RawQuery = url.Values{
+					"X-Amz-Algorithm":     []string{signV4Algorithm},
+					"X-Amz-Credential":    []string{fmt.Sprintf("%s/%s/%s/%s/aws4_request", ak, now.Format(yyyymmdd), region, serviceS3)},
+					"X-Amz-Date":          []string{now.Format(iso8601Format)},
+					"X-Amz-Expires":       []string{tc.expiresIn},
+					"X-Amz-SignedHeaders": []string{"host"},
+				}.Encode()
+			} else {
+				// For header-based authentication
+				req.Header.Set("X-Amz-Date", now.Format(iso8601Format))
+			}
+
+			_, err = signer.Sign(req, Body, serviceS3, region, now)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Mock time passing
+			signature.TimeNow = func() time.Time { return now.Add(tc.timeDelta) }
+
+			result := signature.V4SignVerify(req)
+			if result == signature.ErrNone && tc.expectedError {
+				t.Errorf("invalid result: expected error but got no error")
+			}
+			if result != signature.ErrNone && !tc.expectedError {
+				t.Errorf("invalid result: didn't expect error but got error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Problem**: The current implementation does not verify the expiration of S3 requests

**Fix**: This PR introduces an authentication expiration check for both header-based and query-based S3 requests. It respects the X-Amz-Expires parameter in query-based authentication and applies a default 15-minute expiration for header-based requests. 