### PR TITLE
feat: stream multipart upload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rclone/gofakes3
 
-go 1.18
+go 1.24.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rclone/gofakes3
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.3

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -953,7 +953,7 @@ func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID Upload
 			return err
 		}
 
-		etag, err := upload.AddPart(int(partNumber), g.timeSource.Now(), rdr, size)
+		etag, err := upload.AddPart(r.Context(), int(partNumber), g.timeSource.Now(), rdr, size)
 		if err != nil {
 			return err
 		}
@@ -985,7 +985,7 @@ func (g *GoFakeS3) completeMultipartUpload(bucket, object string, uploadID Uploa
 		return err
 	}
 
-	fileBody, size, err := upload.Reassemble(&in)
+	fileBody, size, err := upload.Reassemble(r.Context(), &in)
 	if err != nil {
 		return err
 	}

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -36,7 +36,7 @@ type GoFakeS3 struct {
 	failOnUnimplementedPage bool
 	hostBucket              bool
 	autoBucket              bool
-	uploader                *uploader
+	uploader                Uploader
 	log                     Logger
 
 	// simple v4 signature
@@ -53,7 +53,7 @@ func New(backend Backend, options ...Option) *GoFakeS3 {
 		timeSkew:          DefaultSkewLimit,
 		metadataSizeLimit: DefaultMetadataSizeLimit,
 		integrityCheck:    true,
-		uploader:          newUploader(newMultipartBackendInMemory()),
+		uploader:          NewUploaderInMemory(NewMultipartBackendInMemory()),
 		requestID:         0,
 	}
 
@@ -626,7 +626,7 @@ func (g *GoFakeS3) createObjectBrowserUpload(bucket string, w http.ResponseWrite
 	}
 
 	// FIXME: how does Content-MD5 get sent when using the browser? does it?
-	rdr, err := newHashingReader(infile, "")
+	rdr, err := NewHashingReader(infile, "")
 	if err != nil {
 		return err
 	}
@@ -699,7 +699,7 @@ func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r 
 
 	// hashingReader is still needed to get the ETag even if integrityCheck
 	// is set to false:
-	rdr, err := newHashingReader(reader, md5Base64)
+	rdr, err := NewHashingReader(reader, md5Base64)
 	defer CheckClose(r.Body, &err)
 	if err != nil {
 		return err
@@ -884,7 +884,7 @@ func (g *GoFakeS3) initiateMultipartUpload(bucket, object string, w http.Respons
 
 	upload := g.uploader.Begin(bucket, object, meta, g.timeSource.Now())
 	out := InitiateMultipartUpload{
-		UploadID: upload.ID,
+		UploadID: upload.GetId(),
 		Bucket:   bucket,
 		Key:      object,
 	}
@@ -948,7 +948,7 @@ func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID Upload
 	}
 
 	{
-		rdr, err := newHashingReader(rdr, expectedMD5Base64)
+		rdr, err := NewHashingReader(rdr, expectedMD5Base64)
 		if err != nil {
 			return err
 		}
@@ -990,7 +990,7 @@ func (g *GoFakeS3) completeMultipartUpload(bucket, object string, uploadID Uploa
 		return err
 	}
 
-	result, err := g.storage.PutObject(r.Context(), bucket, object, upload.Meta, fileBody, size)
+	result, err := g.storage.PutObject(r.Context(), bucket, object, upload.GetMeta(), fileBody, size)
 	if err != nil {
 		return err
 	}

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -53,7 +53,7 @@ func New(backend Backend, options ...Option) *GoFakeS3 {
 		timeSkew:          DefaultSkewLimit,
 		metadataSizeLimit: DefaultMetadataSizeLimit,
 		integrityCheck:    true,
-		uploader:          newUploader(newMemoryTempBlobFactory()),
+		uploader:          newUploader(newMultipartBackendInMemory()),
 		requestID:         0,
 	}
 

--- a/hash.go
+++ b/hash.go
@@ -15,10 +15,11 @@ import (
 // If the expected hash is not empty, once the underlying reader returns EOF,
 // the hash is checked.
 type hashingReader struct {
-	inner    io.Reader
-	expected []byte
-	hash     hash.Hash
-	sum      []byte
+	inner       io.Reader
+	expectedStr string
+	expected    []byte
+	hash        hash.Hash
+	sum         []byte
 }
 
 func newHashingReader(inner io.Reader, optExpectedMD5Base64 string) (*hashingReader, error) {
@@ -40,6 +41,17 @@ func newHashingReader(inner io.Reader, optExpectedMD5Base64 string) (*hashingRea
 		expected: md5Bytes,
 		hash:     md5.New(),
 	}, nil
+}
+
+func (h *hashingReader) GetExpectedMD5() []byte {
+	if h.expected == nil {
+		return nil
+	}
+
+	ret := make([]byte, len(h.expected))
+	copy(ret, h.expected)
+
+	return ret
 }
 
 // Sum returns the hash of the data read from the inner reader so far.

--- a/hash.go
+++ b/hash.go
@@ -21,12 +21,12 @@ type hashingReader struct {
 	sum      []byte
 }
 
-func newHashingReader(inner io.Reader, expectedMD5Base64 string) (*hashingReader, error) {
+func newHashingReader(inner io.Reader, optExpectedMD5Base64 string) (*hashingReader, error) {
 	var md5Bytes []byte
 	var err error
 
-	if expectedMD5Base64 != "" {
-		md5Bytes, err = base64.StdEncoding.DecodeString(expectedMD5Base64)
+	if optExpectedMD5Base64 != "" {
+		md5Bytes, err = base64.StdEncoding.DecodeString(optExpectedMD5Base64)
 		if err != nil {
 			return nil, ErrInvalidDigest
 		}

--- a/hash.go
+++ b/hash.go
@@ -14,6 +14,12 @@ import (
 //
 // If the expected hash is not empty, once the underlying reader returns EOF,
 // the hash is checked.
+type HashingReader interface {
+	io.Reader
+	GetExpectedMD5() []byte
+	Sum(into []byte) []byte
+}
+
 type hashingReader struct {
 	inner       io.Reader
 	expectedStr string
@@ -22,7 +28,7 @@ type hashingReader struct {
 	sum         []byte
 }
 
-func newHashingReader(inner io.Reader, optExpectedMD5Base64 string) (*hashingReader, error) {
+func NewHashingReader(inner io.Reader, optExpectedMD5Base64 string) (HashingReader, error) {
 	var md5Bytes []byte
 	var err error
 

--- a/option.go
+++ b/option.go
@@ -8,6 +8,12 @@ func WithV4Auth(authPair map[string]string) Option {
 	return func(g *GoFakeS3) { g.v4AuthPair = authPair }
 }
 
+// WithTempBlobFactory allors you to not use the standard in memory backend
+// for multipart upload
+func WithTempBlobFactory(factory TempBlobFactory) Option {
+	return func(g *GoFakeS3) { g.uploader = newUploader(factory) }
+}
+
 // WithTimeSource allows you to substitute the behaviour of time.Now() and
 // time.Since() within GoFakeS3. This can be used to trigger time skew errors,
 // or to ensure the output of the commands is deterministic.

--- a/option.go
+++ b/option.go
@@ -8,10 +8,10 @@ func WithV4Auth(authPair map[string]string) Option {
 	return func(g *GoFakeS3) { g.v4AuthPair = authPair }
 }
 
-// WithTempBlobFactory allors you to not use the standard in memory backend
+// WithMultipartBackend allows you to not use the standard in memory backend
 // for multipart upload
-func WithTempBlobFactory(factory MultipartBackend) Option {
-	return func(g *GoFakeS3) { g.uploader = newUploader(factory) }
+func WithUploader(uploader Uploader) Option {
+	return func(g *GoFakeS3) { g.uploader = uploader }
 }
 
 // WithTimeSource allows you to substitute the behaviour of time.Now() and

--- a/option.go
+++ b/option.go
@@ -10,7 +10,7 @@ func WithV4Auth(authPair map[string]string) Option {
 
 // WithTempBlobFactory allors you to not use the standard in memory backend
 // for multipart upload
-func WithTempBlobFactory(factory TempBlobFactory) Option {
+func WithTempBlobFactory(factory MultipartBackend) Option {
 	return func(g *GoFakeS3) { g.uploader = newUploader(factory) }
 }
 

--- a/temp.go
+++ b/temp.go
@@ -1,0 +1,48 @@
+package gofakes3
+
+import (
+	"bytes"
+	"io"
+)
+
+type TempBlobFactory interface {
+	New(bucket, object string, partNumber int, size int64) TempBlob
+}
+
+type TempBlob interface {
+	Reader() io.ReadCloser
+	Writer() io.WriteCloser
+	Cleanup()
+}
+
+func newMemoryTempBlobFactory() TempBlobFactory {
+	return &memoryTempBlobFactory{}
+}
+
+type memoryTempBlobFactory struct{}
+
+// New implements TempBlobFactory.
+func (m *memoryTempBlobFactory) New(bucket, object string, partNumber int, size int64) TempBlob {
+	return &memoryTempBlob{
+		buf: bytes.NewBuffer(make([]byte, 0, size)),
+	}
+}
+
+type memoryTempBlob struct {
+	buf *bytes.Buffer
+}
+
+// Cleanup implements TempBlob.
+func (m *memoryTempBlob) Cleanup() {}
+
+// Reader implements TempBlob.
+func (m *memoryTempBlob) Reader() io.ReadCloser { return io.NopCloser(bytes.NewReader(m.buf.Bytes())) }
+
+// Writer implements TempBlob.
+func (m *memoryTempBlob) Writer() io.WriteCloser { return &nopWriteCloser{m.buf} }
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (wc *nopWriteCloser) Close() error { return nil }

--- a/temp.go
+++ b/temp.go
@@ -2,6 +2,7 @@ package gofakes3
 
 import (
 	"bytes"
+	"context"
 	"io"
 )
 
@@ -10,9 +11,9 @@ type TempBlobFactory interface {
 }
 
 type TempBlob interface {
-	Reader() io.ReadCloser
-	Writer() io.WriteCloser
-	Cleanup()
+	Reader(context.Context) io.ReadCloser
+	Writer(context.Context) io.WriteCloser
+	Cleanup(context.Context)
 }
 
 func newMemoryTempBlobFactory() TempBlobFactory {
@@ -33,13 +34,15 @@ type memoryTempBlob struct {
 }
 
 // Cleanup implements TempBlob.
-func (m *memoryTempBlob) Cleanup() {}
+func (m *memoryTempBlob) Cleanup(context.Context) {}
 
 // Reader implements TempBlob.
-func (m *memoryTempBlob) Reader() io.ReadCloser { return io.NopCloser(bytes.NewReader(m.buf.Bytes())) }
+func (m *memoryTempBlob) Reader(context.Context) io.ReadCloser {
+	return io.NopCloser(bytes.NewReader(m.buf.Bytes()))
+}
 
 // Writer implements TempBlob.
-func (m *memoryTempBlob) Writer() io.WriteCloser { return &nopWriteCloser{m.buf} }
+func (m *memoryTempBlob) Writer(context.Context) io.WriteCloser { return &nopWriteCloser{m.buf} }
 
 type nopWriteCloser struct {
 	io.Writer

--- a/temp.go
+++ b/temp.go
@@ -6,7 +6,7 @@ import (
 )
 
 type TempBlobFactory interface {
-	New(bucket, object string, partNumber int, size int64) TempBlob
+	New(bucket, object string, partNumber int, size int64, expectedMD5 []byte) TempBlob
 }
 
 type TempBlob interface {
@@ -22,7 +22,7 @@ func newMemoryTempBlobFactory() TempBlobFactory {
 type memoryTempBlobFactory struct{}
 
 // New implements TempBlobFactory.
-func (m *memoryTempBlobFactory) New(bucket, object string, partNumber int, size int64) TempBlob {
+func (m *memoryTempBlobFactory) New(bucket, object string, partNumber int, size int64, epectedMD5 []byte) TempBlob {
 	return &memoryTempBlob{
 		buf: bytes.NewBuffer(make([]byte, 0, size)),
 	}

--- a/temp.go
+++ b/temp.go
@@ -6,7 +6,7 @@ import (
 )
 
 type TempBlobFactory interface {
-	New(bucket, object string, partNumber int, size int64, expectedMD5 []byte) TempBlob
+	New(bucket, object string, partNumber int, size int64, expectedMD5 []byte) (TempBlob, error)
 }
 
 type TempBlob interface {
@@ -22,10 +22,10 @@ func newMemoryTempBlobFactory() TempBlobFactory {
 type memoryTempBlobFactory struct{}
 
 // New implements TempBlobFactory.
-func (m *memoryTempBlobFactory) New(bucket, object string, partNumber int, size int64, epectedMD5 []byte) TempBlob {
+func (m *memoryTempBlobFactory) New(bucket, object string, partNumber int, size int64, epectedMD5 []byte) (TempBlob, error) {
 	return &memoryTempBlob{
 		buf: bytes.NewBuffer(make([]byte, 0, size)),
-	}
+	}, nil
 }
 
 type memoryTempBlob struct {

--- a/temp.go
+++ b/temp.go
@@ -6,31 +6,34 @@ import (
 	"io"
 )
 
-type TempBlobFactory interface {
-	New(bucket, object string, partNumber int, size int64, expectedMD5 []byte) (TempBlob, error)
+type MultipartBackend interface {
+	New(bucket, object string, partNumber int, size int64, expectedMD5 []byte) (UploadPart, error)
 }
 
-type TempBlob interface {
+type UploadPart interface {
 	Reader(context.Context) io.ReadCloser
 	Writer(context.Context) io.WriteCloser
 	Cleanup(context.Context)
+	ValidateMD5(context.Context, []byte) error
 }
 
-func newMemoryTempBlobFactory() TempBlobFactory {
-	return &memoryTempBlobFactory{}
+func newMultipartBackendInMemory() MultipartBackend {
+	return &multipartBackendInMemory{}
 }
 
-type memoryTempBlobFactory struct{}
+type multipartBackendInMemory struct{}
 
 // New implements TempBlobFactory.
-func (m *memoryTempBlobFactory) New(bucket, object string, partNumber int, size int64, epectedMD5 []byte) (TempBlob, error) {
+func (m *multipartBackendInMemory) New(bucket, object string, partNumber int, size int64, expectedMD5 []byte) (UploadPart, error) {
 	return &memoryTempBlob{
-		buf: bytes.NewBuffer(make([]byte, 0, size)),
+		buf:         bytes.NewBuffer(make([]byte, 0, size)),
+		expectedMD5: expectedMD5,
 	}, nil
 }
 
 type memoryTempBlob struct {
-	buf *bytes.Buffer
+	buf      *bytes.Buffer
+	expectedMD5 []byte
 }
 
 // Cleanup implements TempBlob.
@@ -43,6 +46,20 @@ func (m *memoryTempBlob) Reader(context.Context) io.ReadCloser {
 
 // Writer implements TempBlob.
 func (m *memoryTempBlob) Writer(context.Context) io.WriteCloser { return &nopWriteCloser{m.buf} }
+
+// ValidateMD5 implements MD5 validation for the uploaded part.
+func (m *memoryTempBlob) ValidateMD5(ctx context.Context, actualMD5 []byte) error {
+	if m.expectedMD5 == nil {
+		// No MD5 validation requested
+		return nil
+	}
+	
+	if !bytes.Equal(actualMD5, m.expectedMD5) {
+		return ErrBadDigest
+	}
+	
+	return nil
+}
 
 type nopWriteCloser struct {
 	io.Writer

--- a/temp.go
+++ b/temp.go
@@ -17,7 +17,7 @@ type UploadPart interface {
 	ValidateMD5(context.Context, []byte) error
 }
 
-func newMultipartBackendInMemory() MultipartBackend {
+func NewMultipartBackendInMemory() MultipartBackend {
 	return &multipartBackendInMemory{}
 }
 
@@ -32,7 +32,7 @@ func (m *multipartBackendInMemory) New(bucket, object string, partNumber int, si
 }
 
 type memoryTempBlob struct {
-	buf      *bytes.Buffer
+	buf         *bytes.Buffer
 	expectedMD5 []byte
 }
 
@@ -53,11 +53,11 @@ func (m *memoryTempBlob) ValidateMD5(ctx context.Context, actualMD5 []byte) erro
 		// No MD5 validation requested
 		return nil
 	}
-	
+
 	if !bytes.Equal(actualMD5, m.expectedMD5) {
 		return ErrBadDigest
 	}
-	
+
 	return nil
 }
 

--- a/temp.go
+++ b/temp.go
@@ -14,7 +14,6 @@ type UploadPart interface {
 	Reader(context.Context) io.ReadCloser
 	Writer(context.Context) io.WriteCloser
 	Cleanup(context.Context)
-	ValidateMD5(context.Context, []byte) error
 }
 
 func NewMultipartBackendInMemory() MultipartBackend {
@@ -46,20 +45,6 @@ func (m *memoryTempBlob) Reader(context.Context) io.ReadCloser {
 
 // Writer implements TempBlob.
 func (m *memoryTempBlob) Writer(context.Context) io.WriteCloser { return &nopWriteCloser{m.buf} }
-
-// ValidateMD5 implements MD5 validation for the uploaded part.
-func (m *memoryTempBlob) ValidateMD5(ctx context.Context, actualMD5 []byte) error {
-	if m.expectedMD5 == nil {
-		// No MD5 validation requested
-		return nil
-	}
-
-	if !bytes.Equal(actualMD5, m.expectedMD5) {
-		return ErrBadDigest
-	}
-
-	return nil
-}
 
 type nopWriteCloser struct {
 	io.Writer

--- a/temp_test.go
+++ b/temp_test.go
@@ -14,188 +14,188 @@ import (
 func testMultipartBackendGeneric(t *testing.T, backendFactory func() MultipartBackend, backendName string) {
 	t.Run(backendName+"_New", func(t *testing.T) {
 		backend := backendFactory()
-		
+
 		// Test normal case
 		part, err := backend.New("test-bucket", "test-object", 1, 1024, []byte("test-md5"))
 		assert.NoError(t, err, "New should not return an error")
 		assert.NotNil(t, part, "New should return a non-nil UploadPart")
-		
+
 		// Test with zero size
 		part, err = backend.New("test-bucket", "test-object", 1, 0, []byte("test-md5"))
 		assert.NoError(t, err, "New should not return an error even with zero size")
 		assert.NotNil(t, part, "New should return a non-nil UploadPart even with zero size")
-		
+
 		// Test with large size
 		part, err = backend.New("test-bucket", "test-object", 1, 1024*1024, []byte("test-md5"))
 		assert.NoError(t, err, "New should not return an error even with large size")
 		assert.NotNil(t, part, "New should return a non-nil UploadPart even with large size")
 	})
-	
+
 	t.Run(backendName+"_UploadPartOperations", func(t *testing.T) {
 		backend := backendFactory()
-		
+
 		// Test Cleanup
 		t.Run("Cleanup", func(t *testing.T) {
 			part, err := backend.New("test-bucket", "test-object", 1, 1024, []byte("test-md5"))
 			require.NoError(t, err)
-			
+
 			// Cleanup should not panic or return any error
 			part.Cleanup(context.Background())
-			
+
 			// Cleanup is idempotent, should be safe to call multiple times
 			part.Cleanup(context.Background())
 		})
-		
+
 		// Test Writer and Reader
 		t.Run("WriterAndReader", func(t *testing.T) {
 			part, err := backend.New("test-bucket", "test-object", 1, 1024, []byte("test-md5"))
 			require.NoError(t, err)
-			
+
 			writer := part.Writer(context.Background())
 			testData := []byte("Hello, World!")
 			n, err := writer.Write(testData)
 			require.NoError(t, err)
 			require.Equal(t, len(testData), n)
 			require.NoError(t, writer.Close())
-			
+
 			reader := part.Reader(context.Background())
 			defer reader.Close()
-			
+
 			readData, err := io.ReadAll(reader)
 			require.NoError(t, err)
 			require.Equal(t, testData, readData)
 		})
-		
+
 		// Test Multiple Writes
 		t.Run("MultipleWrites", func(t *testing.T) {
 			part, err := backend.New("test-bucket", "test-object", 1, 1024, []byte("test-md5"))
 			require.NoError(t, err)
-			
+
 			writer := part.Writer(context.Background())
-			
+
 			data1 := []byte("First chunk")
 			data2 := []byte("Second chunk")
 			data3 := []byte("Third chunk")
-			
+
 			n1, err := writer.Write(data1)
 			require.NoError(t, err)
 			require.Equal(t, len(data1), n1)
-			
+
 			n2, err := writer.Write(data2)
 			require.NoError(t, err)
 			require.Equal(t, len(data2), n2)
-			
+
 			n3, err := writer.Write(data3)
 			require.NoError(t, err)
 			require.Equal(t, len(data3), n3)
-			
+
 			require.NoError(t, writer.Close())
-			
+
 			reader := part.Reader(context.Background())
 			defer reader.Close()
-			
+
 			expectedData := append(append(data1, data2...), data3...)
 			actualData, err := io.ReadAll(reader)
 			require.NoError(t, err)
 			require.Equal(t, expectedData, actualData)
 		})
-		
+
 		// Test Empty Data
 		t.Run("EmptyData", func(t *testing.T) {
 			part, err := backend.New("test-bucket", "test-object", 1, 1024, []byte("test-md5"))
 			require.NoError(t, err)
-			
+
 			reader := part.Reader(context.Background())
 			defer reader.Close()
-			
+
 			data, err := io.ReadAll(reader)
 			require.NoError(t, err)
 			require.Empty(t, data, "Empty temp blob should return empty data")
 		})
-		
+
 		// Test Large Data
 		t.Run("LargeData", func(t *testing.T) {
 			part, err := backend.New("test-bucket", "test-object", 1, 1024*1024, []byte("test-md5"))
 			require.NoError(t, err)
-			
+
 			writer := part.Writer(context.Background())
-			
+
 			largeData := make([]byte, 1024*1024)
 			for i := range largeData {
 				largeData[i] = byte(i % 256)
 			}
-			
+
 			n, err := writer.Write(largeData)
 			require.NoError(t, err)
 			require.Equal(t, len(largeData), n)
 			require.NoError(t, writer.Close())
-			
+
 			reader := part.Reader(context.Background())
 			defer reader.Close()
-			
+
 			readData, err := io.ReadAll(reader)
 			require.NoError(t, err)
 			require.Equal(t, largeData, readData)
 		})
-		
+
 		// Test MD5 Validation
 		t.Run("MD5Validation", func(t *testing.T) {
 			// Test with correct MD5
 			t.Run("CorrectMD5", func(t *testing.T) {
 				testData := []byte("Hello, World!")
 				expectedMD5 := []byte("test-md5-correct")
-				
+
 				part, err := backend.New("test-bucket", "test-object", 1, 1024, expectedMD5)
 				require.NoError(t, err)
-				
+
 				// Write data
 				writer := part.Writer(context.Background())
 				n, err := writer.Write(testData)
 				require.NoError(t, err)
 				require.Equal(t, len(testData), n)
 				require.NoError(t, writer.Close())
-				
+
 				// Validate with correct MD5
 				err = part.ValidateMD5(context.Background(), expectedMD5)
 				require.NoError(t, err, "MD5 validation should pass with correct MD5")
 			})
-			
+
 			// Test with incorrect MD5
 			t.Run("IncorrectMD5", func(t *testing.T) {
 				testData := []byte("Hello, World!")
 				expectedMD5 := []byte("test-md5-correct")
 				incorrectMD5 := []byte("test-md5-incorrect")
-				
+
 				part, err := backend.New("test-bucket", "test-object", 1, 1024, expectedMD5)
 				require.NoError(t, err)
-				
+
 				// Write data
 				writer := part.Writer(context.Background())
 				n, err := writer.Write(testData)
 				require.NoError(t, err)
 				require.Equal(t, len(testData), n)
 				require.NoError(t, writer.Close())
-				
+
 				// Validate with incorrect MD5 - should fail
 				err = part.ValidateMD5(context.Background(), incorrectMD5)
 				require.Error(t, err, "MD5 validation should fail with incorrect MD5")
 				assert.Equal(t, ErrBadDigest, err, "Error should be ErrBadDigest")
 			})
-			
+
 			// Test with no MD5 validation (nil expected MD5)
 			t.Run("NoMD5Validation", func(t *testing.T) {
 				testData := []byte("Hello, World!")
-				
+
 				part, err := backend.New("test-bucket", "test-object", 1, 1024, nil)
 				require.NoError(t, err)
-				
+
 				// Write data
 				writer := part.Writer(context.Background())
 				n, err := writer.Write(testData)
 				require.NoError(t, err)
 				require.Equal(t, len(testData), n)
 				require.NoError(t, writer.Close())
-				
+
 				// Validate with any MD5 - should pass since no validation was requested
 				err = part.ValidateMD5(context.Background(), []byte("any-md5"))
 				require.NoError(t, err, "MD5 validation should pass when no validation was requested")
@@ -207,7 +207,7 @@ func testMultipartBackendGeneric(t *testing.T, backendFactory func() MultipartBa
 // TestMemoryTempBlobGeneric applies the generic test to the in-memory backend
 func TestMemoryTempBlobGeneric(t *testing.T) {
 	testMultipartBackendGeneric(t, func() MultipartBackend {
-		return newMultipartBackendInMemory()
+		return NewMultipartBackendInMemory()
 	}, "MemoryTempBlob")
 }
 
@@ -225,17 +225,17 @@ func TestNopWriteCloser(t *testing.T) {
 	// Test the nopWriteCloser helper
 	buf := &bytes.Buffer{}
 	wc := &nopWriteCloser{Writer: buf}
-	
+
 	// Test writing
 	testData := []byte("Test data")
 	n, err := wc.Write(testData)
 	require.NoError(t, err)
 	require.Equal(t, len(testData), n)
 	require.Equal(t, testData, buf.Bytes())
-	
+
 	// Test closing (should not return error)
 	require.NoError(t, wc.Close())
-	
+
 	// Test that Close is idempotent
 	require.NoError(t, wc.Close())
 }

--- a/temp_test.go
+++ b/temp_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testMultipartBackendGeneric is a generic helper function that can test any MultipartBackend implementation
-func testMultipartBackendGeneric(t *testing.T, backendFactory func() MultipartBackend, backendName string) {
+// TestMultipartBackendGeneric is a generic helper function that can test any MultipartBackend implementation
+func TestMultipartBackendGeneric(t *testing.T, backendFactory func() MultipartBackend, backendName string) {
 	t.Run(backendName+"_New", func(t *testing.T) {
 		backend := backendFactory()
 
@@ -154,17 +154,12 @@ func testMultipartBackendGeneric(t *testing.T, backendFactory func() MultipartBa
 				require.NoError(t, err)
 				require.Equal(t, len(testData), n)
 				require.NoError(t, writer.Close())
-
-				// Validate with correct MD5
-				err = part.ValidateMD5(context.Background(), expectedMD5)
-				require.NoError(t, err, "MD5 validation should pass with correct MD5")
 			})
 
 			// Test with incorrect MD5
 			t.Run("IncorrectMD5", func(t *testing.T) {
 				testData := []byte("Hello, World!")
 				expectedMD5 := []byte("test-md5-correct")
-				incorrectMD5 := []byte("test-md5-incorrect")
 
 				part, err := backend.New("test-bucket", "test-object", 1, 1024, expectedMD5)
 				require.NoError(t, err)
@@ -175,11 +170,6 @@ func testMultipartBackendGeneric(t *testing.T, backendFactory func() MultipartBa
 				require.NoError(t, err)
 				require.Equal(t, len(testData), n)
 				require.NoError(t, writer.Close())
-
-				// Validate with incorrect MD5 - should fail
-				err = part.ValidateMD5(context.Background(), incorrectMD5)
-				require.Error(t, err, "MD5 validation should fail with incorrect MD5")
-				assert.Equal(t, ErrBadDigest, err, "Error should be ErrBadDigest")
 			})
 
 			// Test with no MD5 validation (nil expected MD5)
@@ -195,10 +185,6 @@ func testMultipartBackendGeneric(t *testing.T, backendFactory func() MultipartBa
 				require.NoError(t, err)
 				require.Equal(t, len(testData), n)
 				require.NoError(t, writer.Close())
-
-				// Validate with any MD5 - should pass since no validation was requested
-				err = part.ValidateMD5(context.Background(), []byte("any-md5"))
-				require.NoError(t, err, "MD5 validation should pass when no validation was requested")
 			})
 		})
 	})
@@ -206,7 +192,7 @@ func testMultipartBackendGeneric(t *testing.T, backendFactory func() MultipartBa
 
 // TestMemoryTempBlobGeneric applies the generic test to the in-memory backend
 func TestMemoryTempBlobGeneric(t *testing.T) {
-	testMultipartBackendGeneric(t, func() MultipartBackend {
+	TestMultipartBackendGeneric(t, func() MultipartBackend {
 		return NewMultipartBackendInMemory()
 	}, "MemoryTempBlob")
 }

--- a/temp_test.go
+++ b/temp_test.go
@@ -1,0 +1,241 @@
+package gofakes3
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testMultipartBackendGeneric is a generic helper function that can test any MultipartBackend implementation
+func testMultipartBackendGeneric(t *testing.T, backendFactory func() MultipartBackend, backendName string) {
+	t.Run(backendName+"_New", func(t *testing.T) {
+		backend := backendFactory()
+		
+		// Test normal case
+		part, err := backend.New("test-bucket", "test-object", 1, 1024, []byte("test-md5"))
+		assert.NoError(t, err, "New should not return an error")
+		assert.NotNil(t, part, "New should return a non-nil UploadPart")
+		
+		// Test with zero size
+		part, err = backend.New("test-bucket", "test-object", 1, 0, []byte("test-md5"))
+		assert.NoError(t, err, "New should not return an error even with zero size")
+		assert.NotNil(t, part, "New should return a non-nil UploadPart even with zero size")
+		
+		// Test with large size
+		part, err = backend.New("test-bucket", "test-object", 1, 1024*1024, []byte("test-md5"))
+		assert.NoError(t, err, "New should not return an error even with large size")
+		assert.NotNil(t, part, "New should return a non-nil UploadPart even with large size")
+	})
+	
+	t.Run(backendName+"_UploadPartOperations", func(t *testing.T) {
+		backend := backendFactory()
+		
+		// Test Cleanup
+		t.Run("Cleanup", func(t *testing.T) {
+			part, err := backend.New("test-bucket", "test-object", 1, 1024, []byte("test-md5"))
+			require.NoError(t, err)
+			
+			// Cleanup should not panic or return any error
+			part.Cleanup(context.Background())
+			
+			// Cleanup is idempotent, should be safe to call multiple times
+			part.Cleanup(context.Background())
+		})
+		
+		// Test Writer and Reader
+		t.Run("WriterAndReader", func(t *testing.T) {
+			part, err := backend.New("test-bucket", "test-object", 1, 1024, []byte("test-md5"))
+			require.NoError(t, err)
+			
+			writer := part.Writer(context.Background())
+			testData := []byte("Hello, World!")
+			n, err := writer.Write(testData)
+			require.NoError(t, err)
+			require.Equal(t, len(testData), n)
+			require.NoError(t, writer.Close())
+			
+			reader := part.Reader(context.Background())
+			defer reader.Close()
+			
+			readData, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.Equal(t, testData, readData)
+		})
+		
+		// Test Multiple Writes
+		t.Run("MultipleWrites", func(t *testing.T) {
+			part, err := backend.New("test-bucket", "test-object", 1, 1024, []byte("test-md5"))
+			require.NoError(t, err)
+			
+			writer := part.Writer(context.Background())
+			
+			data1 := []byte("First chunk")
+			data2 := []byte("Second chunk")
+			data3 := []byte("Third chunk")
+			
+			n1, err := writer.Write(data1)
+			require.NoError(t, err)
+			require.Equal(t, len(data1), n1)
+			
+			n2, err := writer.Write(data2)
+			require.NoError(t, err)
+			require.Equal(t, len(data2), n2)
+			
+			n3, err := writer.Write(data3)
+			require.NoError(t, err)
+			require.Equal(t, len(data3), n3)
+			
+			require.NoError(t, writer.Close())
+			
+			reader := part.Reader(context.Background())
+			defer reader.Close()
+			
+			expectedData := append(append(data1, data2...), data3...)
+			actualData, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.Equal(t, expectedData, actualData)
+		})
+		
+		// Test Empty Data
+		t.Run("EmptyData", func(t *testing.T) {
+			part, err := backend.New("test-bucket", "test-object", 1, 1024, []byte("test-md5"))
+			require.NoError(t, err)
+			
+			reader := part.Reader(context.Background())
+			defer reader.Close()
+			
+			data, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.Empty(t, data, "Empty temp blob should return empty data")
+		})
+		
+		// Test Large Data
+		t.Run("LargeData", func(t *testing.T) {
+			part, err := backend.New("test-bucket", "test-object", 1, 1024*1024, []byte("test-md5"))
+			require.NoError(t, err)
+			
+			writer := part.Writer(context.Background())
+			
+			largeData := make([]byte, 1024*1024)
+			for i := range largeData {
+				largeData[i] = byte(i % 256)
+			}
+			
+			n, err := writer.Write(largeData)
+			require.NoError(t, err)
+			require.Equal(t, len(largeData), n)
+			require.NoError(t, writer.Close())
+			
+			reader := part.Reader(context.Background())
+			defer reader.Close()
+			
+			readData, err := io.ReadAll(reader)
+			require.NoError(t, err)
+			require.Equal(t, largeData, readData)
+		})
+		
+		// Test MD5 Validation
+		t.Run("MD5Validation", func(t *testing.T) {
+			// Test with correct MD5
+			t.Run("CorrectMD5", func(t *testing.T) {
+				testData := []byte("Hello, World!")
+				expectedMD5 := []byte("test-md5-correct")
+				
+				part, err := backend.New("test-bucket", "test-object", 1, 1024, expectedMD5)
+				require.NoError(t, err)
+				
+				// Write data
+				writer := part.Writer(context.Background())
+				n, err := writer.Write(testData)
+				require.NoError(t, err)
+				require.Equal(t, len(testData), n)
+				require.NoError(t, writer.Close())
+				
+				// Validate with correct MD5
+				err = part.ValidateMD5(context.Background(), expectedMD5)
+				require.NoError(t, err, "MD5 validation should pass with correct MD5")
+			})
+			
+			// Test with incorrect MD5
+			t.Run("IncorrectMD5", func(t *testing.T) {
+				testData := []byte("Hello, World!")
+				expectedMD5 := []byte("test-md5-correct")
+				incorrectMD5 := []byte("test-md5-incorrect")
+				
+				part, err := backend.New("test-bucket", "test-object", 1, 1024, expectedMD5)
+				require.NoError(t, err)
+				
+				// Write data
+				writer := part.Writer(context.Background())
+				n, err := writer.Write(testData)
+				require.NoError(t, err)
+				require.Equal(t, len(testData), n)
+				require.NoError(t, writer.Close())
+				
+				// Validate with incorrect MD5 - should fail
+				err = part.ValidateMD5(context.Background(), incorrectMD5)
+				require.Error(t, err, "MD5 validation should fail with incorrect MD5")
+				assert.Equal(t, ErrBadDigest, err, "Error should be ErrBadDigest")
+			})
+			
+			// Test with no MD5 validation (nil expected MD5)
+			t.Run("NoMD5Validation", func(t *testing.T) {
+				testData := []byte("Hello, World!")
+				
+				part, err := backend.New("test-bucket", "test-object", 1, 1024, nil)
+				require.NoError(t, err)
+				
+				// Write data
+				writer := part.Writer(context.Background())
+				n, err := writer.Write(testData)
+				require.NoError(t, err)
+				require.Equal(t, len(testData), n)
+				require.NoError(t, writer.Close())
+				
+				// Validate with any MD5 - should pass since no validation was requested
+				err = part.ValidateMD5(context.Background(), []byte("any-md5"))
+				require.NoError(t, err, "MD5 validation should pass when no validation was requested")
+			})
+		})
+	})
+}
+
+// TestMemoryTempBlobGeneric applies the generic test to the in-memory backend
+func TestMemoryTempBlobGeneric(t *testing.T) {
+	testMultipartBackendGeneric(t, func() MultipartBackend {
+		return newMultipartBackendInMemory()
+	}, "MemoryTempBlob")
+}
+
+// Example of how to use the generic test with a different backend implementation
+// This is commented out since we don't have another implementation, but shows the pattern
+/*
+func TestSomeOtherBackendGeneric(t *testing.T) {
+	testMultipartBackendGeneric(t, func() MultipartBackend {
+		return newSomeOtherBackend() // hypothetical other backend implementation
+	}, "SomeOtherBackend")
+}
+*/
+
+func TestNopWriteCloser(t *testing.T) {
+	// Test the nopWriteCloser helper
+	buf := &bytes.Buffer{}
+	wc := &nopWriteCloser{Writer: buf}
+	
+	// Test writing
+	testData := []byte("Test data")
+	n, err := wc.Write(testData)
+	require.NoError(t, err)
+	require.Equal(t, len(testData), n)
+	require.Equal(t, testData, buf.Bytes())
+	
+	// Test closing (should not return error)
+	require.NoError(t, wc.Close())
+	
+	// Test that Close is idempotent
+	require.NoError(t, wc.Close())
+}

--- a/uploader.go
+++ b/uploader.go
@@ -526,8 +526,10 @@ func (mpu *multipartUpload) Reassemble(input *CompleteMultipartUploadRequest) (b
 
 	readers := make([]io.Reader, len(input.Parts))
 	for i, inPart := range input.Parts {
-		reader := mpu.parts[inPart.PartNumber].TempBlob.Reader()
+		tmpBlob := mpu.parts[inPart.PartNumber].TempBlob
+		reader := tmpBlob.Reader()
 		defer reader.Close()
+		defer tmpBlob.Cleanup()
 
 		readers[i] = reader
 	}

--- a/uploader.go
+++ b/uploader.go
@@ -459,7 +459,11 @@ func (mpu *multipartUpload) AddPart(partNumber int, at time.Time, body *hashingR
 		return "", ErrInvalidPart
 	}
 
-	tempBlob := mpu.tempBlobFactory.New(mpu.Bucket, mpu.Object, partNumber, size, body.GetExpectedMD5())
+	tempBlob, err := mpu.tempBlobFactory.New(mpu.Bucket, mpu.Object, partNumber, size, body.GetExpectedMD5())
+	if err != nil {
+		return "", err
+	}
+
 	w := tempBlob.Writer()
 	defer w.Close()
 

--- a/uploader.go
+++ b/uploader.go
@@ -459,7 +459,7 @@ func (mpu *multipartUpload) AddPart(partNumber int, at time.Time, body *hashingR
 		return "", ErrInvalidPart
 	}
 
-	tempBlob := mpu.tempBlobFactory.New(mpu.Bucket, mpu.Object, partNumber, size)
+	tempBlob := mpu.tempBlobFactory.New(mpu.Bucket, mpu.Object, partNumber, size, body.GetExpectedMD5())
 	w := tempBlob.Writer()
 	defer w.Close()
 

--- a/uploader.go
+++ b/uploader.go
@@ -156,10 +156,10 @@ type uploader struct {
 	buckets map[string]*bucketUploads
 	mu      sync.Mutex
 
-	tempBlobFactory TempBlobFactory
+	tempBlobFactory MultipartBackend
 }
 
-func newUploader(tempBlobFactory TempBlobFactory) *uploader {
+func newUploader(tempBlobFactory MultipartBackend) *uploader {
 	return &uploader{
 		buckets:         make(map[string]*bucketUploads),
 		uploadID:        new(big.Int),
@@ -425,7 +425,7 @@ func uploadListMarkerFromQuery(q url.Values) *UploadListMarker {
 type multipartUploadPart struct {
 	PartNumber   int
 	ETag         string
-	TempBlob     TempBlob
+	TempBlob     UploadPart
 	Size         int64
 	LastModified ContentTime
 }
@@ -450,7 +450,7 @@ type multipartUpload struct {
 	//
 	// Do not attempt to access parts without locking mu.
 	parts           []*multipartUploadPart
-	tempBlobFactory TempBlobFactory
+	tempBlobFactory MultipartBackend
 
 	mu sync.Mutex
 }

--- a/uploader.go
+++ b/uploader.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"maps"
 	"math/big"
 	"net/url"
 	"strings"
@@ -64,7 +65,7 @@ in a 100,000 element array of 80-ish byte strings takes barely 1ms.
 */
 type bucketUploads struct {
 	// uploads should be protected by the coarse lock in uploader:
-	uploads map[UploadID]*multipartUpload
+	uploads map[UploadID]*multipartUploadInMemory
 
 	// objectIndex provides sorted traversal of the bucket uploads.
 	//
@@ -77,20 +78,20 @@ type bucketUploads struct {
 
 func newBucketUploads() *bucketUploads {
 	return &bucketUploads{
-		uploads:     map[UploadID]*multipartUpload{},
+		uploads:     map[UploadID]*multipartUploadInMemory{},
 		objectIndex: skiplist.NewStringMap(),
 	}
 }
 
 // add assumes uploader.mu is acquired
-func (bu *bucketUploads) add(mpu *multipartUpload) {
+func (bu *bucketUploads) add(mpu *multipartUploadInMemory) {
 	bu.uploads[mpu.ID] = mpu
 
 	uploads, ok := bu.objectIndex.Get(mpu.Object)
 	if !ok {
-		uploads = []*multipartUpload{mpu}
+		uploads = []*multipartUploadInMemory{mpu}
 	} else {
-		uploads = append(uploads.([]*multipartUpload), mpu)
+		uploads = append(uploads.([]*multipartUploadInMemory), mpu)
 	}
 	bu.objectIndex.Set(mpu.Object, uploads)
 }
@@ -100,17 +101,17 @@ func (bu *bucketUploads) remove(uploadID UploadID) {
 	upload := bu.uploads[uploadID]
 	delete(bu.uploads, uploadID)
 
-	var uploads []*multipartUpload
+	var uploads []*multipartUploadInMemory
 	{
 		upv, ok := bu.objectIndex.Get(upload.Object)
 		if !ok || upv == nil {
 			return
 		}
-		uploads = upv.([]*multipartUpload)
+		uploads = upv.([]*multipartUploadInMemory)
 	}
 
 	var found = -1
-	var v *multipartUpload
+	var v *multipartUploadInMemory
 	for found, v = range uploads {
 		if v.ID == uploadID {
 			break
@@ -148,7 +149,16 @@ func (bu *bucketUploads) remove(uploadID UploadID) {
 // good convenience for Backend implementers if their use case did not require
 // persistent multipart upload handling, or it could be satisfied by this
 // naive implementation.
-type uploader struct {
+// Uploader interface defines the contract for multipart upload management
+type Uploader interface {
+	Begin(bucket, object string, meta map[string]string, initiated time.Time) MultipartUpload
+	ListParts(bucket, object string, uploadID UploadID, marker int, limit int64) (*ListMultipartUploadPartsResult, error)
+	List(bucket string, marker *UploadListMarker, prefix Prefix, limit int64) (*ListMultipartUploadsResult, error)
+	Complete(bucket, object string, id UploadID) (MultipartUpload, error)
+	Get(bucket, object string, id UploadID) (MultipartUpload, error)
+}
+
+type uploaderInMemory struct {
 	// uploadIDs use a big.Int to allow unbounded IDs (not that you'd be
 	// expected to ever generate 4.2 billion of these but who are we to judge?)
 	uploadID *big.Int
@@ -159,21 +169,21 @@ type uploader struct {
 	tempBlobFactory MultipartBackend
 }
 
-func newUploader(tempBlobFactory MultipartBackend) *uploader {
-	return &uploader{
+func NewUploaderInMemory(backend MultipartBackend) Uploader {
+	return &uploaderInMemory{
 		buckets:         make(map[string]*bucketUploads),
 		uploadID:        new(big.Int),
-		tempBlobFactory: tempBlobFactory,
+		tempBlobFactory: backend,
 	}
 }
 
-func (u *uploader) Begin(bucket, object string, meta map[string]string, initiated time.Time) *multipartUpload {
+func (u *uploaderInMemory) Begin(bucket, object string, meta map[string]string, initiated time.Time) MultipartUpload {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
 	u.uploadID.Add(u.uploadID, add1)
 
-	mpu := &multipartUpload{
+	mpu := &multipartUploadInMemory{
 		ID:              UploadID(u.uploadID.String()),
 		Bucket:          bucket,
 		Object:          object,
@@ -194,7 +204,7 @@ func (u *uploader) Begin(bucket, object string, meta map[string]string, initiate
 	return mpu
 }
 
-func (u *uploader) ListParts(bucket, object string, uploadID UploadID, marker int, limit int64) (*ListMultipartUploadPartsResult, error) {
+func (u *uploaderInMemory) ListParts(bucket, object string, uploadID UploadID, marker int, limit int64) (*ListMultipartUploadPartsResult, error) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
@@ -237,7 +247,7 @@ func (u *uploader) ListParts(bucket, object string, uploadID UploadID, marker in
 	return &result, nil
 }
 
-func (u *uploader) List(bucket string, marker *UploadListMarker, prefix Prefix, limit int64) (*ListMultipartUploadsResult, error) {
+func (u *uploaderInMemory) List(bucket string, marker *UploadListMarker, prefix Prefix, limit int64) (*ListMultipartUploadsResult, error) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
@@ -280,7 +290,7 @@ func (u *uploader) List(bucket string, marker *UploadListMarker, prefix Prefix, 
 
 	for iter.Next() {
 		object := iter.Key().(string)
-		uploads := iter.Value().([]*multipartUpload)
+		uploads := iter.Value().([]*multipartUploadInMemory)
 
 	retry:
 		matched := prefix.Match(object, &match)
@@ -338,7 +348,7 @@ done:
 
 				// This is not especially defensive; it assumes the rest of the code works
 				// as it should. Could be something to clean up later:
-				result.NextUploadIDMarker = iter.Value().([]*multipartUpload)[0].ID
+				result.NextUploadIDMarker = iter.Value().([]*multipartUploadInMemory)[0].ID
 				result.NextKeyMarker = object
 				break
 			}
@@ -350,7 +360,7 @@ done:
 	return &result, nil
 }
 
-func (u *uploader) Complete(bucket, object string, id UploadID) (*multipartUpload, error) {
+func (u *uploaderInMemory) Complete(bucket, object string, id UploadID) (MultipartUpload, error) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	up, err := u.getUnlocked(bucket, object, id)
@@ -364,13 +374,13 @@ func (u *uploader) Complete(bucket, object string, id UploadID) (*multipartUploa
 	return up, nil
 }
 
-func (u *uploader) Get(bucket, object string, id UploadID) (mu *multipartUpload, err error) {
+func (u *uploaderInMemory) Get(bucket, object string, id UploadID) (mu MultipartUpload, err error) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	return u.getUnlocked(bucket, object, id)
 }
 
-func (u *uploader) getUnlocked(bucket, object string, id UploadID) (mu *multipartUpload, err error) {
+func (u *uploaderInMemory) getUnlocked(bucket, object string, id UploadID) (mu *multipartUploadInMemory, err error) {
 	bucketUps, ok := u.buckets[bucket]
 	if !ok {
 		return nil, ErrNoSuchUpload
@@ -422,7 +432,7 @@ func uploadListMarkerFromQuery(q url.Values) *UploadListMarker {
 	return &UploadListMarker{Object: object, UploadID: UploadID(q.Get("upload-id-marker"))}
 }
 
-type multipartUploadPart struct {
+type MultipartUploadPart struct {
 	PartNumber   int
 	ETag         string
 	TempBlob     UploadPart
@@ -430,7 +440,15 @@ type multipartUploadPart struct {
 	LastModified ContentTime
 }
 
-type multipartUpload struct {
+type MultipartUpload interface {
+	GetId() UploadID
+	GetMeta() map[string]string
+
+	AddPart(ctx context.Context, partNumber int, at time.Time, body HashingReader, size int64) (etag string, err error)
+	Reassemble(ctx context.Context, input *CompleteMultipartUploadRequest) (body HashingReader, size int64, err error)
+}
+
+type multipartUploadInMemory struct {
 	ID        UploadID
 	Bucket    string
 	Object    string
@@ -449,13 +467,23 @@ type multipartUpload struct {
 	// always be nil.
 	//
 	// Do not attempt to access parts without locking mu.
-	parts           []*multipartUploadPart
+	parts           []*MultipartUploadPart
 	tempBlobFactory MultipartBackend
 
 	mu sync.Mutex
 }
 
-func (mpu *multipartUpload) AddPart(ctx context.Context, partNumber int, at time.Time, body *hashingReader, size int64) (etag string, err error) {
+// GetId implements [MultipartUpload].
+func (mpu *multipartUploadInMemory) GetId() UploadID {
+	return mpu.ID
+}
+
+// GetMeta implements [MultipartUpload].
+func (mpu *multipartUploadInMemory) GetMeta() map[string]string {
+	return maps.Clone(mpu.Meta)
+}
+
+func (mpu *multipartUploadInMemory) AddPart(ctx context.Context, partNumber int, at time.Time, body HashingReader, size int64) (etag string, err error) {
 	if partNumber > MaxUploadPartNumber {
 		return "", ErrInvalidPart
 	}
@@ -481,7 +509,7 @@ func (mpu *multipartUpload) AddPart(ctx context.Context, partNumber int, at time
 	mpu.mu.Lock()
 	defer mpu.mu.Unlock()
 
-	part := multipartUploadPart{
+	part := MultipartUploadPart{
 		PartNumber:   partNumber,
 		TempBlob:     tempBlob,
 		ETag:         etag,
@@ -489,13 +517,13 @@ func (mpu *multipartUpload) AddPart(ctx context.Context, partNumber int, at time
 		LastModified: NewContentTime(at),
 	}
 	if partNumber >= len(mpu.parts) {
-		mpu.parts = append(mpu.parts, make([]*multipartUploadPart, partNumber-len(mpu.parts)+1)...)
+		mpu.parts = append(mpu.parts, make([]*MultipartUploadPart, partNumber-len(mpu.parts)+1)...)
 	}
 	mpu.parts[partNumber] = &part
 	return etag, nil
 }
 
-func (mpu *multipartUpload) Reassemble(ctx context.Context, input *CompleteMultipartUploadRequest) (body *hashingReader, size int64, err error) {
+func (mpu *multipartUploadInMemory) Reassemble(ctx context.Context, input *CompleteMultipartUploadRequest) (body HashingReader, size int64, err error) {
 	mpu.mu.Lock()
 	defer mpu.mu.Unlock()
 
@@ -535,7 +563,7 @@ func (mpu *multipartUpload) Reassemble(ctx context.Context, input *CompleteMulti
 		readers[i] = reader
 	}
 
-	body, err = newHashingReader(io.MultiReader(readers...), "")
+	body, err = NewHashingReader(io.MultiReader(readers...), "")
 	if err != nil {
 		return nil, 0, err
 	}

--- a/uploader_test.go
+++ b/uploader_test.go
@@ -7,7 +7,32 @@ import (
 	"github.com/rclone/gofakes3"
 )
 
-func TestMultipartUpload(t *testing.T) {
+func TestMultipartAllInMemory(t *testing.T) {
+	testMultipartAll(t, func() gofakes3.Uploader { return gofakes3.NewUploaderInMemory(gofakes3.NewMultipartBackendInMemory()) })
+}
+
+func testMultipartAll(t *testing.T, newUploader func() gofakes3.Uploader) {
+	t.Run("testMultipartUpload", func(t *testing.T) {
+		testMultipartUpload(t, newUploader())
+	})
+	t.Run("testAbortMultipartUpload", func(t *testing.T) {
+		testAbortMultipartUpload(t, newUploader())
+	})
+	t.Run("testListMultipartUploadsWithTheSameObjectKey", func(t *testing.T) {
+		testListMultipartUploadsWithTheSameObjectKey(t, newUploader())
+	})
+	t.Run("testListMultipartUploadsWithDifferentObjectKeys", func(t *testing.T) {
+		testListMultipartUploadsWithDifferentObjectKeys(t, newUploader())
+	})
+	t.Run("testListMultipartUploadsPrefix", func(t *testing.T) {
+		testListMultipartUploadsPrefix(t, newUploader())
+	})
+	t.Run("testListMultipartUploadParts", func(t *testing.T) {
+		testListMultipartUploadParts(t, newUploader())
+	})
+}
+
+func testMultipartUpload(t *testing.T, uploader gofakes3.Uploader) {
 	const size = defaultUploadPartSize
 
 	for _, tc := range []struct {
@@ -25,7 +50,7 @@ func TestMultipartUpload(t *testing.T) {
 		// {parts: 100, size: 10 * 1024 * 1024, last: 1},
 	} {
 		t.Run("", func(t *testing.T) {
-			ts := newTestServer(t)
+			ts := newTestServer(t, withFakerOptions(gofakes3.WithUploader(uploader)))
 			defer ts.Close()
 
 			var size int64
@@ -41,8 +66,8 @@ func TestMultipartUpload(t *testing.T) {
 	}
 }
 
-func TestAbortMultipartUpload(t *testing.T) {
-	ts := newTestServer(t)
+func testAbortMultipartUpload(t *testing.T, uploader gofakes3.Uploader) {
+	ts := newTestServer(t, withFakerOptions(gofakes3.WithUploader(uploader)))
 	defer ts.Close()
 
 	ts.createMultipartUpload(defaultBucket, "obj", nil)
@@ -52,8 +77,8 @@ func TestAbortMultipartUpload(t *testing.T) {
 	ts.assertAbortMultipartUpload(defaultBucket, "obj", "1")
 }
 
-func TestListMultipartUploadsWithTheSameObjectKey(t *testing.T) {
-	ts := newTestServer(t)
+func testListMultipartUploadsWithTheSameObjectKey(t *testing.T, uploader gofakes3.Uploader) {
+	ts := newTestServer(t, withFakerOptions(gofakes3.WithUploader(uploader)))
 	defer ts.Close()
 
 	ts.createMultipartUpload(defaultBucket, "obj", nil)
@@ -76,8 +101,8 @@ func TestListMultipartUploadsWithTheSameObjectKey(t *testing.T) {
 		Marker: "obj/2", Limit: 2, Uploads: strs("obj/2", "obj/3")})
 }
 
-func TestListMultipartUploadsWithDifferentObjectKeys(t *testing.T) {
-	ts := newTestServer(t)
+func testListMultipartUploadsWithDifferentObjectKeys(t *testing.T, uploader gofakes3.Uploader) {
+	ts := newTestServer(t, withFakerOptions(gofakes3.WithUploader(uploader)))
 	defer ts.Close()
 
 	ts.createMultipartUpload(defaultBucket, "foo", nil)
@@ -100,8 +125,8 @@ func TestListMultipartUploadsWithDifferentObjectKeys(t *testing.T) {
 		Marker: "baz/3", Limit: 2, Uploads: strs("baz/3", "foo/1")})
 }
 
-func TestListMultipartUploadsPrefix(t *testing.T) {
-	ts := newTestServer(t)
+func testListMultipartUploadsPrefix(t *testing.T, uploader gofakes3.Uploader) {
+	ts := newTestServer(t, withFakerOptions(gofakes3.WithUploader(uploader)))
 	defer ts.Close()
 
 	ts.createMultipartUpload(defaultBucket, "foo/bar", nil)
@@ -138,8 +163,8 @@ func TestListMultipartUploadsPrefix(t *testing.T) {
 	//     Uploads:  strs("foo/bar/1", "foo/bar/2")})
 }
 
-func TestListMultipartUploadParts(t *testing.T) {
-	ts := newTestServer(t)
+func testListMultipartUploadParts(t *testing.T, uploader gofakes3.Uploader) {
+	ts := newTestServer(t, withFakerOptions(gofakes3.WithUploader(uploader)))
 	defer ts.Close()
 
 	id := ts.createMultipartUpload(defaultBucket, "foo", nil)


### PR DESCRIPTION
This is the first stone to solve :
https://github.com/rclone/rclone/issues/7453

What is does:
- Implements streaming with reader instead of []byte
- The rclone backend has to implement a TempBlobFactory which can be linked to the VFS or the  underlying storage backend as each temp blob is created with New(bucket, object string, partNumber int, size int64)

Comments are appreciated