### PR TITLE
Fix ContentTime XML to emit UTC timestamps

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -97,7 +97,7 @@ func NewContentTime(t time.Time) ContentTime {
 func (c ContentTime) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	// This is the format expected by the aws xml code, not the default.
 	if !c.IsZero() {
-		var s = c.Format("2006-01-02T15:04:05.999Z")
+		var s = c.UTC().Format("2006-01-02T15:04:05.999Z")
 		return e.EncodeElement(s, start)
 	}
 	return nil

--- a/messages_test.go
+++ b/messages_test.go
@@ -52,6 +52,31 @@ func TestContentTime(t *testing.T) {
 	}
 }
 
+func TestContentTimeConvertsToUTC(t *testing.T) {
+	type testMsg struct {
+		Foo  string
+		Time ContentTime
+	}
+	const expected = "" +
+		"<testMsg>" +
+		"<Foo>bar</Foo>" +
+		"<Time>2019-01-01T13:00:00Z</Time>" +
+		"</testMsg>"
+
+	cst := time.FixedZone("CST", -6*3600)
+	var v = testMsg{
+		Foo:  "bar",
+		Time: NewContentTime(time.Date(2019, 1, 1, 7, 0, 0, 0, cst)),
+	}
+	out, err := xml.Marshal(&v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(out) != expected {
+		t.Fatalf("unexpected XML output: %s", string(out))
+	}
+}
+
 func TestContentTimeOmitEmpty(t *testing.T) {
 	type testMsg struct {
 		Foo  string


### PR DESCRIPTION
  ## Summary
  ContentTime.MarshalXML was formatting local time with a literal "Z" suffix, which labels the time as UTC without converting it. This caused LastModified in S3 XML responses to be shifted by the local timezone offset.

  ## Changes
  - Convert ContentTime to UTC before formatting in MarshalXML.
  - Add test to verify conversion from a fixed local timezone to UTC.

  ## How to reproduce (before fix)
  1. Run rclone serve s3 locally.
  2. Upload with awscli:
     aws s3 cp test.txt s3://bucket/test.txt --endpoint-url http://localhost:9000
  3. Observe:
     aws s3 ls s3://bucket/test.txt --endpoint-url http://localhost:9000
     (timestamp appears shifted by local timezone offset)

  ## Expected
  LastModified should be correct UTC when suffixed with "Z".
