### PR TITLE
Feat/ctx cancelable read

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -510,7 +510,7 @@ func (g *GoFakeS3) getObject(
 	// Writes Content-Length, and Content-Range if applicable:
 	obj.Range.writeHeader(obj.Size, w)
 
-	if _, err := io.Copy(w, obj.Contents); err != nil {
+	if _, err := io.Copy(w, NewContextReader(r.Context(), obj.Contents)); err != nil {
 		return err
 	}
 

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -1367,3 +1367,61 @@ func TestGetObjectResponseOverride(t *testing.T) {
 		}
 	})
 }
+
+func TestContextCancellationGetObjectCopy(t *testing.T) {
+	ts := newTestServer(t, withBackend(&infiniteReadBackend{s3mem.New()}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.url(defaultBucket+"/anything"), nil)
+		if err != nil {
+			done <- err
+			return
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			done <- err
+			return
+		}
+		defer resp.Body.Close()
+		_, err = io.ReadAll(resp.Body)
+		done <- err
+	}()
+
+	// ensure io.Copy starts before cancel
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected (at least some) error on cancel")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetObject did not terminate after context cancellation")
+	}
+}
+
+type infiniteReadBackend struct {
+	gofakes3.Backend
+}
+
+func (b *infiniteReadBackend) GetObject(ctx context.Context, bucket, object string, rnge *gofakes3.ObjectRangeRequest) (*gofakes3.Object, error) {
+	return &gofakes3.Object{
+		Name:     object,
+		Size:     1<<62 - 1,
+		Contents: io.NopCloser(zeroReader{}),
+	}, nil
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}

--- a/s3mem/backend.go
+++ b/s3mem/backend.go
@@ -102,6 +102,9 @@ func (db *Backend) ListBucket(ctx context.Context, name string, prefix *gofakes3
 	var lastMatchedPart string
 
 	for iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		item := iter.Value().(*bucketObject)
 
 		if !prefix.Match(item.data.name, &match) {
@@ -222,7 +225,7 @@ func (db *Backend) PutObject(ctx context.Context, bucketName, objectName string,
 	// No need to lock the backend while we read the data into memory; it holds
 	// the write lock open unnecessarily, and could be blocked for an unreasonably
 	// long time by a connection timing out:
-	bts, err := gofakes3.ReadAll(input, size)
+	bts, err := gofakes3.ReadAll(gofakes3.NewContextReader(ctx, input), size)
 	if err != nil {
 		return result, err
 	}

--- a/util.go
+++ b/util.go
@@ -78,9 +78,6 @@ func (cr *contextReader) WriteTo(w io.Writer) (int64, error) {
 	if err := cr.ctx.Err(); err != nil {
 		return 0, err
 	}
-	if wt, ok := cr.r.(io.WriterTo); ok {
-		return wt.WriteTo(w)
-	}
-	buf := make([]byte, 4<<20)
+	buf := make([]byte, 4<<10)
 	return io.CopyBuffer(w, cr.r, buf)
 }

--- a/util.go
+++ b/util.go
@@ -73,3 +73,14 @@ func (cr *contextReader) Read(p []byte) (int, error) {
 	}
 	return cr.r.Read(p)
 }
+
+func (cr *contextReader) WriteTo(w io.Writer) (int64, error) {
+	if err := cr.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if wt, ok := cr.r.(io.WriterTo); ok {
+		return wt.WriteTo(w)
+	}
+	buf := make([]byte, 4<<20)
+	return io.CopyBuffer(w, cr.r, buf)
+}

--- a/util.go
+++ b/util.go
@@ -1,6 +1,7 @@
 package gofakes3
 
 import (
+	"context"
 	"io"
 	"strconv"
 )
@@ -54,4 +55,21 @@ func ReadAll(r io.Reader, size int64) (b []byte, err error) {
 	}
 
 	return b, nil
+}
+
+// NewContextReader - context aware Reader treating context `Err()`s as Read errors
+func NewContextReader(ctx context.Context, r io.Reader) io.Reader {
+	return &contextReader{ctx: ctx, r: r}
+}
+
+type contextReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (cr *contextReader) Read(p []byte) (int, error) {
+	if err := cr.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return cr.r.Read(p)
 }

--- a/util.go
+++ b/util.go
@@ -78,6 +78,5 @@ func (cr *contextReader) WriteTo(w io.Writer) (int64, error) {
 	if err := cr.ctx.Err(); err != nil {
 		return 0, err
 	}
-	buf := make([]byte, 4<<10)
-	return io.CopyBuffer(w, cr.r, buf)
+	return io.Copy(w, cr.r)
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,6 +1,7 @@
 package gofakes3
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -59,6 +60,25 @@ func TestReadAll(t *testing.T) {
 		_, err := ReadAll(strings.NewReader("test"), 3)
 		if !HasErrorCode(err, ErrIncompleteBody) {
 			t.Fatal("expected ErrIncompleteBody, found", err)
+		}
+	})
+}
+
+func TestNewContextReader(t *testing.T) {
+	t.Run("simple-read", func(t *testing.T) {
+		tt := TT{t}
+		b, err := ReadAll(NewContextReader(t.Context(), strings.NewReader("test")), 4)
+		tt.OK(err)
+		if string(b) != "test" {
+			t.Fatal(string(b), "!=", "test")
+		}
+	})
+	t.Run("canceled-ctx", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+		_, err := ReadAll(NewContextReader(ctx, strings.NewReader("test")), 4)
+		if err == nil {
+			t.Fatal("expected error when reading with canceled context")
 		}
 	})
 }


### PR DESCRIPTION
`rclone serve s3` currently does not propagate a cancelled request to the io/file reader level. This PR introduce support for checking context `Err()`s on every read.

some context/use case: I'm using `rclone serve` to expose a zfs dataset stored on mechanical disks. I sometimes accidentally (or just to check if possible/how fast stuff is) issue s3 queries that would scan a lot of this dataset. Realizing such a command will take too much time I'll ctrl+c, but the server will still execute the command to completion. In my case that equates to 99% disk usage for a long time, possibly preventing/stalling actual io ops I want to execute.