### PR TITLE
fix: Do not write trailing headers as part of object data

### DIFF
--- a/chunk.go
+++ b/chunk.go
@@ -48,16 +48,29 @@ func (r *chunkedReader) Read(p []byte) (n int, err error) {
 			}
 			// read next chunk header
 			chunkSize := 0
-			_, err = fmt.Fscanf(r.inner, "%x;", &chunkSize)
+			_, err = fmt.Fscanf(r.inner, "%x", &chunkSize)
 			if err != nil {
 				return n, err
 			}
 			r.chunkRemain = chunkSize
-			_, err = io.CopyN(io.Discard, r.inner, 16+64+2) // "chunk-signature=" + sizeOfHash + "\r\n"
-			if err != nil {
+			if err := discardLine(r.inner); err != nil {
 				return n, err
 			}
 		}
 	}
 	return n, nil
+}
+
+// discardLine discards bytes up to and including '\n'.
+func discardLine(r io.Reader) error {
+	var b [1]byte
+	for {
+		_, err := io.ReadFull(r, b[:])
+		if err != nil {
+			return err
+		}
+		if b[0] == '\n' {
+			return nil
+		}
+	}
 }

--- a/chunk.go
+++ b/chunk.go
@@ -1,19 +1,20 @@
 package gofakes3
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 )
 
 type chunkedReader struct {
-	inner         io.Reader
+	inner         *bufio.Reader
 	chunkRemain   int
 	notFirstChunk bool
 }
 
 func newChunkedReader(inner io.Reader) *chunkedReader {
 	return &chunkedReader{
-		inner:         inner,
+		inner:         bufio.NewReader(inner),
 		chunkRemain:   0,
 		notFirstChunk: false,
 	}
@@ -62,15 +63,7 @@ func (r *chunkedReader) Read(p []byte) (n int, err error) {
 }
 
 // discardLine discards bytes up to and including '\n'.
-func discardLine(r io.Reader) error {
-	var b [1]byte
-	for {
-		_, err := io.ReadFull(r, b[:])
-		if err != nil {
-			return err
-		}
-		if b[0] == '\n' {
-			return nil
-		}
-	}
+func discardLine(r *bufio.Reader) error {
+	_, err := r.ReadSlice('\n')
+	return err
 }

--- a/chunk_test.go
+++ b/chunk_test.go
@@ -34,6 +34,18 @@ func TestChunkedUploadSuccess(t *testing.T) {
 	assert.Equal(t, string(buf), strings.Repeat("a", 65536+1024))
 }
 
+func TestChunkedUploadSuccessUnsignedTrailer(t *testing.T) {
+	payload := "5\r\n"
+	payload += "hello\r\n"
+	payload += "0\r\n"
+
+	inner := strings.NewReader(payload)
+	chunkedReader := newChunkedReader(inner)
+	buf, err := io.ReadAll(chunkedReader)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "hello", string(buf))
+}
+
 type errReader struct{}
 
 func (errReader) Read(p []byte) (n int, err error) {

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -704,7 +704,7 @@ func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r 
 
 	var reader io.Reader
 
-	if sha, ok := meta["X-Amz-Content-Sha256"]; ok && sha == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" {
+	if isChunkedStreamingPayload(meta["X-Amz-Content-Sha256"]) {
 		reader = newChunkedReader(r.Body)
 	} else {
 		reader = r.Body
@@ -954,7 +954,7 @@ func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID Upload
 	}
 
 	var rdr io.Reader
-	if sha, ok := meta["X-Amz-Content-Sha256"]; ok && sha == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" {
+	if isChunkedStreamingPayload(meta["X-Amz-Content-Sha256"]) {
 		rdr = newChunkedReader(r.Body)
 		size, err = strconv.ParseInt(meta["X-Amz-Decoded-Content-Length"], 10, 64)
 		if err != nil {
@@ -1009,6 +1009,12 @@ func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID Upload
 
 	w.Header().Add("ETag", etag)
 	return nil
+}
+
+// isChunkedStreamingPayload reports whether x-amz-content-sha256 denotes aws-chunked transfer encoding.
+func isChunkedStreamingPayload(value string) bool {
+	return value == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" ||
+		value == "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
 }
 
 func (g *GoFakeS3) abortMultipartUpload(bucket, object string, uploadID UploadID, w http.ResponseWriter, r *http.Request) error {

--- a/gofakes3.go
+++ b/gofakes3.go
@@ -706,14 +706,22 @@ func (g *GoFakeS3) createObject(bucket, object string, w http.ResponseWriter, r 
 
 	if sha, ok := meta["X-Amz-Content-Sha256"]; ok && sha == "STREAMING-AWS4-HMAC-SHA256-PAYLOAD" {
 		reader = newChunkedReader(r.Body)
+	} else {
+		reader = r.Body
+	}
+
+	// This header is set e.g. when the body contains trailing headers
+	// It is used to extract real object length
+	if _, ok := meta["X-Amz-Decoded-Content-Length"]; ok {
 		size, err = strconv.ParseInt(meta["X-Amz-Decoded-Content-Length"], 10, 64)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest) // XXX: no code for this, according to s3tests
 			return nil
 		}
-	} else {
-		reader = r.Body
 	}
+
+	// Ensure reader only contains object (strips the trailing headers)
+	reader = io.LimitReader(reader, size)
 
 	// hashingReader is still needed to get the ETag even if integrityCheck
 	// is set to false:
@@ -956,6 +964,19 @@ func (g *GoFakeS3) putMultipartUploadPart(bucket, object string, uploadID Upload
 	} else {
 		rdr = r.Body
 	}
+
+	// This header is set e.g. when the body contains trailing headers
+	// It is used to extract real object length
+	if _, ok := meta["X-Amz-Decoded-Content-Length"]; ok {
+		size, err = strconv.ParseInt(meta["X-Amz-Decoded-Content-Length"], 10, 64)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest) // XXX: no code for this, according to s3tests
+			return nil
+		}
+	}
+
+	// Ensure reader only contains object (strips the trailing headers)
+	rdr = io.LimitReader(rdr, size)
 
 	if g.integrityCheck {
 		md5Base64 := r.Header.Get("Content-MD5")

--- a/gofakes3_test.go
+++ b/gofakes3_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
 	"reflect"
@@ -19,6 +20,7 @@ import (
 	xml "github.com/minio/xxml"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/rclone/gofakes3"
@@ -156,6 +158,37 @@ func TestCreateObject(t *testing.T) {
 	if *out.ETag != `"5d41402abc4b2a76b9719d911017c592"` { // md5("hello")
 		ts.Fatal("bad etag", out.ETag)
 	}
+
+	obj := ts.backendGetString(defaultBucket, "object", nil)
+	if obj != "hello" {
+		t.Fatal("object creation failed")
+	}
+}
+
+func TestCreateObjectTrailingHeaders(t *testing.T) {
+	ts := newTestServer(t)
+	defer ts.Close()
+	ctx := context.Background()
+	tlsServer := httptest.NewTLSServer(ts.GoFakeS3.Server())
+	defer tlsServer.Close()
+
+	svc := s3.NewFromConfig(aws.Config{Region: "region"}, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(tlsServer.URL)
+		o.UsePathStyle = true
+		o.HTTPClient = tlsServer.Client()
+		o.Credentials = &credentials.StaticCredentialsProvider{Value: aws.Credentials{
+			AccessKeyID:     "dummy-access",
+			SecretAccessKey: "dummy-secret",
+		}}
+	})
+
+	_, err := svc.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:            aws.String(defaultBucket),
+		Key:               aws.String("object"),
+		Body:              bytes.NewReader([]byte("hello")),
+		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
+	})
+	ts.OK(err)
 
 	obj := ts.backendGetString(defaultBucket, "object", nil)
 	if obj != "hello" {


### PR DESCRIPTION
AWS has a feature "trailing headers" which can be used to calculate the checksum of an object (either uploaded directly or via multipart) after uploading by, by specifying a "header" *after* the content. When these headers are present, `X-Amz-Decoded-Content-Length` will indicate the real length of the object.

This PR always reads `X-Amz-Decoded-Content-Length` whenever available, allowing it to not write the trailing headers as part of the object.

This corrects objects corruption by rclone whenever chunked uploads/trailing headers are used by clients

Documentation: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming-trailers.html

Example of object corruption:
`mcli cp /bin/docker test/mybucket/docker --checksum SHA1 && mcli cp test/mybucket/docker ./docker && du -b /bin/docker /home/itrooz/tmp/mybucket/docker ./docker`
(Try a small and a large file to try both normal and multipart paths)